### PR TITLE
Migrate to python-memcache

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,13 @@ møte - Fedora meetbot log wrangler
 
 ### About
 
-møte allows the Fedora community to search and explore IRC meetings. 
+møte allows the Fedora community to search and explore IRC meetings.
 More information on meetings can be found [here](https://fedoraproject.org/wiki/Meeting_channel?rd=Fedora_meeting_channel)
 
 ### Using møte
 
-Dependencies: 
+Dependencies:
  - `memcached` (`sudo yum install memcached`)
- - `libmemcached`, `libmemcached-devel` (`sudo yum install libmemcached libmemcached-devel`)
  - Python 2.7.x
 
 `pip` Dependencies:
@@ -22,10 +21,9 @@ Running møte:
 
 ### Contribute to møte
 
-You can contribute code or data. møte is in need of contributors to increase it's name association data pool. 
+You can contribute code or data. møte is in need of contributors to increase it's name association data pool.
 Some of the meeting groups' names are difficult to understand: for instance, the term `famna` may be unfamiliar to prospective ambassadors. To help add friendlier names and create a clear grouping of meeting groups, you can fork, edit, and send a pull request to the following data files:
 
 https://github.com/fedora-infra/mote/blob/master/name_mappings.json
 
 https://github.com/fedora-infra/mote/blob/master/category_mappings.json
-

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Running møte:
 
 ### Contribute to møte
 
-You can contribute code or data. møte is in need of contributors to increase it's name association data pool.
+You can contribute code or data. møte is in need of contributors to increase its name association data pool.
 Some of the meeting groups' names are difficult to understand: for instance, the term `famna` may be unfamiliar to prospective ambassadors. To help add friendlier names and create a clear grouping of meeting groups, you can fork, edit, and send a pull request to the following data files:
 
 https://github.com/fedora-infra/mote/blob/master/name_mappings.json

--- a/files/mote.spec
+++ b/files/mote.spec
@@ -2,7 +2,7 @@
 %distutils.sysconfig import get_python_lib; print (get_python_lib())")}
 
 Name:     mote
-Version:  0.0.3b2
+Version:  0.0.4b1
 Release:  1%{?dist}
 Summary:  A meetbot log wrangler, providing a user-friendly interface for Fedora's logs.
 
@@ -15,8 +15,6 @@ Source0:  %{name}-%{version}.tar.gz
 BuildRequires: python2-devel
 BuildRequires: python-pip
 BuildRequires: memcached
-BuildRequires: libmemcached
-BuildRequires: libmemcached-devel
 BuildRequires: mod_wsgi
 BuildRequires: python-flask
 BuildRequires: python-fedora
@@ -32,8 +30,6 @@ BuildRequires: python-fedora-flask
 Requires: python2
 Requires: python-pip
 Requires: memcached
-Requires: libmemcached
-Requires: libmemcached-devel
 Requires: mod_wsgi
 Requires: python-flask
 Requires: python-fedora
@@ -85,8 +81,8 @@ install -m 644 files/mote.wsgi $RPM_BUILD_ROOT/%{_datadir}/mote/mote.wsgi
 %{python_sitelib}/mote*.egg-info
 
 %changelog
-* Mar May 26 2015 Chaoyi Zha <cydrobolt@fedoraproject.org>
-- Update 0.0.3 Beta 2
+* Tue May 26 2015 Chaoyi Zha <cydrobolt@fedoraproject.org>
+- Update 0.0.4 Beta 1
 - Migrate to python-memcached from pylibmc
 * Sat May 23 2015 Chaoyi Zha <cydrobolt@fedoraproject.org>
 - Update 0.0.3 Beta 1

--- a/files/mote.spec
+++ b/files/mote.spec
@@ -81,11 +81,7 @@ install -m 644 files/mote.wsgi $RPM_BUILD_ROOT/%{_datadir}/mote/mote.wsgi
 %{python_sitelib}/mote*.egg-info
 
 %changelog
-<<<<<<< HEAD
 * Tue May 26 2015 Chaoyi Zha <cydrobolt@fedoraproject.org>
-=======
-* Tues May 26 2015 Chaoyi Zha <cydrobolt@fedoraproject.org>
->>>>>>> b50064278f1e3b477a7a2b3928f10f29a776f605
 - Update 0.0.4 Beta 1
 - Migrate to python-memcached from pylibmc
 * Sat May 23 2015 Chaoyi Zha <cydrobolt@fedoraproject.org>

--- a/files/mote.spec
+++ b/files/mote.spec
@@ -2,7 +2,7 @@
 %distutils.sysconfig import get_python_lib; print (get_python_lib())")}
 
 Name:     mote
-Version:  0.0.3b1
+Version:  0.0.3b2
 Release:  1%{?dist}
 Summary:  A meetbot log wrangler, providing a user-friendly interface for Fedora's logs.
 
@@ -21,7 +21,7 @@ BuildRequires: mod_wsgi
 BuildRequires: python-flask
 BuildRequires: python-fedora
 BuildRequires: python-openid
-BuildRequires: python-pylibmc
+BuildRequires: python-memcached
 BuildRequires: python-openid-cla
 BuildRequires: python-openid-teams
 BuildRequires: python-requests
@@ -38,7 +38,7 @@ Requires: mod_wsgi
 Requires: python-flask
 Requires: python-fedora
 Requires: python-openid
-Requires: python-pylibmc
+Requires: python-memcached
 Requires: python-openid-cla
 Requires: python-openid-teams
 Requires: python-requests
@@ -85,7 +85,9 @@ install -m 644 files/mote.wsgi $RPM_BUILD_ROOT/%{_datadir}/mote/mote.wsgi
 %{python_sitelib}/mote*.egg-info
 
 %changelog
-
+* Mar May 26 2015 Chaoyi Zha <cydrobolt@fedoraproject.org>
+- Update 0.0.3 Beta 2
+- Migrate to python-memcached from pylibmc
 * Sat May 23 2015 Chaoyi Zha <cydrobolt@fedoraproject.org>
 - Update 0.0.3 Beta 1
 - Multiple fixes to bugs blocking successful build

--- a/mote/soke.py
+++ b/mote/soke.py
@@ -14,9 +14,7 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 
-# mote searching module
-
-import pylibmc, os, json, re, sys
+import memcache, os, json, re, sys
 from os.path import join, getsize, split, abspath
 
 try:
@@ -35,13 +33,12 @@ reload(sys)
 sys.setdefaultencoding("utf-8")
 
 # The "mc" variable can be used to map to memcached.
-mc = pylibmc.Client([config.memcached_ip], binary=True,
-                    behaviors={"tcp_nodelay": True, "ketama": True})
+mc = memcache.Client([config.memcached_ip], debug=0)
 def memcached_dict_add(dictn, key, val, cxn=mc):
     # Add a key to a dictionary in memcached.
-    u_dictn = mc[dictn]
+    u_dictn = mc.get(dictn)
     u_dictn[key] = val
-    mc[dictn] = u_dictn
+    mc.set(dictn, u_dictn)
 
 def get_date_fn(filename):
     # Return a meeting's date from a filename.
@@ -112,5 +109,5 @@ def run():
                 except:
                     pass
 
-    mc["mote:channel_meetings"] = d_channel_meetings
-    mc["mote:team_meetings"] = t_channel_meetings
+    mc.set("mote:channel_meetings", d_channel_meetings)
+    mc.set("mote:team_meetings", t_channel_meetings)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@ beautifulsoup4==4.3.2
 itsdangerous==0.24
 kitchen==1.2.1
 munch==2.0.2
-pylibmc==1.4.2
 python-dateutil==2.4.2
 python-fedora==0.4.0
+python-memcached==1.54
 python-openid==2.2.5
 python-openid-cla==1.0
 python-openid-teams==1.0


### PR DESCRIPTION
Since `python-pylibmc` is not available in EPEL7, we are migrating to `python-memcached`.