### PR TITLE
Convert POST endpoints to GET.

### DIFF
--- a/mote/__init__.py
+++ b/mote/__init__.py
@@ -14,8 +14,6 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 
-import collections
-
 import flask, random, string, json, util, os, re
 import dateutil.parser, requests, collections
 from bs4 import BeautifulSoup

--- a/mote/static/js/single-log.js
+++ b/mote/static/js/single-log.js
@@ -24,7 +24,7 @@ function loadLogContents() {
         "file_name": current_fname,
     };
     $.ajax({
-      type: "POST",
+      type: "GET",
       url: "/get_meeting_log",
       data: data,
       dataType: "html"

--- a/mote/static/js/sresults.js
+++ b/mote/static/js/sresults.js
@@ -31,7 +31,7 @@ function openLogModal(fname) {
         "file_name": fname,
     };
     $.ajax({
-      type: "POST",
+      type: "GET",
       url: "/get_meeting_log",
       data: data,
       dataType: "html"
@@ -79,7 +79,7 @@ function showLogs(date_stamp) {
     };
     $("#minlogs").html("<i class='fa fa-spinner fa-4x fa-spin'></i>");
     $.ajax({
-      type: "POST",
+      type: "GET",
       url: "/request_logs",
       data: data,
       success: function (res) {


### PR DESCRIPTION
POST doesn't actually make sense here.  It is for when you want to
*change* some data on the server.  Here, we are just requesting that the
server send us some logs -- so that should be a *GET*.

Furthermore, POSTs make things unnecessarily hard to debug, since you can't
easily copy around URLs from the developer console to play with.

I also modified those flask endpoints to return real ``404`` status codes.
If we want to markup 404 pages, we can add a flask 404 handler to catch and
decorate those.