### PR TITLE
Loosen requirements on date parsing regex.

### DIFF
--- a/mote/soke.py
+++ b/mote/soke.py
@@ -44,9 +44,9 @@ def memcached_dict_add(dictn, key, val):
 
 def get_date_fn(filename):
     # Return a meeting's date from a filename.
-    m = re.search(".*?\.([0-9]{4}\-[0-9]{2}\-[0-9]{2})\-.*", filename)
+    m = re.search(".*?[\-\.]([0-9]{4}\-[0-9]{2}\-[0-9]{2})[\-\.].*", filename)
     if m == None:
-        return "Date Undefined"
+        raise ValueError("Failed to parse date from %r" % filename)
     return m.group(1)
 
 


### PR DESCRIPTION
And also complain loudly when we cannot parse a date.

This is should fix #25.

We were failing to parse some dates and returning 'Date Undefined' which was then being cached and causing problems in other parts of the stack which tried to parse that string.