### PR TITLE
Use https/http where appropriate

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ møte - Fedora meetbot log wrangler
 ### About
 
 møte allows the Fedora community to search and explore IRC meetings.
-More information on meetings can be found [here](https://fedoraproject.org/wiki/Meeting_channel?rd=Fedora_meeting_channel)
+More information on meetings can be found [here](https://fedoraproject.org/wiki/Meeting_channel)
 
 ### Using møte
 

--- a/mote/templates/base.html
+++ b/mote/templates/base.html
@@ -41,7 +41,7 @@
             </div>
             <div class="container hidden-sm hidden-xs">
                 <footer class="text-muted">
-                    <p>møte: <a target="_blank" href="//github.com/fedora-infra/mote">sources</a>. &copy; Copyright 2015 <a href="//cydrobolt.com">Chaoyi Zha</a>, <a href="//threebean.org">Ralph Bean</a>, and <a href="https://github.com/fedora-infra/mote/graphs/contributors">others</a>.</p>
+                    <p>møte: <a target="_blank" href="https://github.com/fedora-infra/mote">sources</a>. &copy; Copyright 2015 <a href="https://cydrobolt.com">Chaoyi Zha</a>, <a href="http://threebean.org">Ralph Bean</a>, and <a href="https://github.com/fedora-infra/mote/graphs/contributors">others</a>.</p>
                 </footer>
             </div>
         </div>

--- a/mote/templates/debug-list.html
+++ b/mote/templates/debug-list.html
@@ -20,13 +20,13 @@
                         <i>Minutes</i>
                         <ul>
                             {% for minutes in cm_links["minutes"] %}
-                            <li><a href="http://meetbot.fedoraproject.org/{{cm_key}}/{{cm_date}}/{{minutes}}">{{minutes}}</a></li>
+                            <li><a href="https://meetbot.fedoraproject.org/{{cm_key}}/{{cm_date}}/{{minutes}}">{{minutes}}</a></li>
                             {% endfor %}
                         </ul>
                         <i>Logs</i>
                         <ul>
                             {% for logs in cm_links["logs"] %}
-                            <li><a href="http://meetbot.fedoraproject.org/{{cm_key}}/{{cm_date}}/{{logs}}">{{logs}}</a></li>
+                            <li><a href="https://meetbot.fedoraproject.org/{{cm_key}}/{{cm_date}}/{{logs}}">{{logs}}</a></li>
                             {% endfor %}
                         </ul>
                     {% endfor %}
@@ -49,13 +49,13 @@
                         <i>Minutes</i>
                         <ul>
                             {% for minutes in tm_links["minutes"] %}
-                            <li><a href="http://meetbot.fedoraproject.org/teams/{{tm_key}}/{{minutes}}">{{minutes}}</a></li>
+                            <li><a href="https://meetbot.fedoraproject.org/teams/{{tm_key}}/{{minutes}}">{{minutes}}</a></li>
                             {% endfor %}
                         </ul>
                         <i>Logs</i>
                         <ul>
                             {% for logs in tm_links["logs"] %}
-                            <li><a href="http://meetbot.fedoraproject.org/teams/{{tm_key}}/{{logs}}">{{logs}}</a></li>
+                            <li><a href="https://meetbot.fedoraproject.org/teams/{{tm_key}}/{{logs}}">{{logs}}</a></li>
                             {% endfor %}
                         </ul>
                     {% endfor %}

--- a/mote/templates/index.html
+++ b/mote/templates/index.html
@@ -11,7 +11,7 @@
     <p>møte allows the Fedora community to search and explore IRC meetings.
     <br />
     More information on meetings can be found
-    <a target="_blank" href="https://fedoraproject.org/wiki/Meeting_channel?rd=Fedora_meeting_channel">here</a>,
+    <a target="_blank" href="https://fedoraproject.org/wiki/Meeting_channel">here</a>,
     and more information on møte can be found <a target="_blank" href="https://fedoraproject.org/wiki/Fedora_Infrastructure_Mote">here</a>.<br />
     Use the search bar below to select the meeting group you are looking for in order to locate the appropriate logs.</p>
     <br />


### PR DESCRIPTION
threebean.org does not support https, therefore always use http. The
other links support https, so use them always. Also remove an unneeded
URL parameter from the wiki link.