### PR TITLE
Improved README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Dependencies:
  - Install using `python setup.py develop`
 
 Running møte:
- - Edit [config.py](https://github.com/fedora-infra/mote/blob/master/files/config.py) with necessary information and place the `config.py` in [mote/config.py](https://github.com/fedora-infra/mote/tree/master/mote)
+ - Edit [config.py](https://github.com/fedora-infra/mote/blob/master/files/config.py) with necessary information and place the `config.py` in [mote](https://github.com/fedora-infra/mote/tree/master/mote)
  - Run `python runmote.py`
 
 ### Contribute to møte

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Dependencies:
  - Python 2.7.x
 
 `pip` Dependencies:
- - Install using ``python setup.py develop`
+ - Install using `python setup.py develop`
 
 Running møte:
- - Edit `files/config.py` with necessary information and place `config.py` in `mote/config.py`
+ - Edit [config.py](https://github.com/fedora-infra/mote/blob/master/files/config.py) with necessary information and place the `config.py` in [mote/config.py](https://github.com/fedora-infra/mote/tree/master/mote)
  - Run `python runmote.py`
 
 ### Contribute to møte
@@ -26,6 +26,5 @@ Running møte:
 You can contribute code or data. møte is in need of contributors to increase its name association data pool.
 Some of the meeting groups' names are difficult to understand: for instance, the term `famna` may be unfamiliar to prospective ambassadors. To help add friendlier names and create a clear grouping of meeting groups, you can fork, edit, and send a pull request to the following data files:
 
-https://github.com/fedora-infra/mote/blob/master/name_mappings.json
-
-https://github.com/fedora-infra/mote/blob/master/category_mappings.json
+ - [name_mappings](https://github.com/fedora-infra/mote/blob/master/name_mappings.json)
+ - [category_mappings](https://github.com/fedora-infra/mote/blob/master/category_mappings.json)


### PR DESCRIPTION
Added link to [config.py](https://github.com/fedora-infra/mote/blob/master/files/config.py) and [mote](https://github.com/fedora-infra/mote/tree/master/mote) and  removed unnecessary back quote. Also, replaced unnecessary long url for [name_mappings](https://github.com/fedora-infra/mote/blob/master/name_mappings.json) and [category_mappings](https://github.com/fedora-infra/mote/blob/master/category_mappings.json)