### PR TITLE
Drop "Fedora Board", use "Fedora Council"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ møte - Fedora meetbot log wrangler
 ### About
 
 møte allows the Fedora community to search and explore IRC meetings.
-More information on meetings can be found [here](https://fedoraproject.org/wiki/Meeting_channel)
+More information on meetings can be found [here](https://fedoraproject.org/wiki/Meeting_channel).
 
 ### Using møte
 
 Dependencies:
- - Optional: `memcached` (`sudo yum install memcached`)
+ - Optional: `memcached` (`sudo dnf install memcached`)
  - Python 2.7.x
 
 `pip` Dependencies:

--- a/category_mappings.json
+++ b/category_mappings.json
@@ -1,16 +1,16 @@
 {
-    "Project Leadership": ["board"],
-    "Engineering Leadership": ["fesco"],
-    "Ambassadors": ["famna", "#fedora-ambassadors"],
-    "Infrastructure": ["infrastructure", "#fedora-apps", "#fedora-admin"],
+    "Ambassadors": ["famna", "emea_ambassadors", "#fedora-ambassadors"],
     "Design": ["fedora-design"],
     "Documentation": ["fedora-docs"],
-    "Epel": ["epel"],
+    "Engineering Leadership": ["fesco"],
+    "EPEL": ["epel"],
     "Globalization": ["g11n"],
+    "Infrastructure": ["infrastructure", "#fedora-apps", "#fedora-admin"],
     "Internationalization": ["i18n"],
     "Marketing": ["fedora-mktg"],
     "Packaging": ["fpc"],
+    "Project Leadership": ["board", "council"],
     "Quality Assurance": ["fedora-qa"],
-    "Websites": ["fedora-websites"],
-    "Release Engineering": ["releng"]
+    "Release Engineering": ["releng"],
+    "Websites": ["fedora-websites"]
 }

--- a/category_mappings.json
+++ b/category_mappings.json
@@ -1,5 +1,6 @@
 {
     "Ambassadors": ["famna", "emea_ambassadors", "#fedora-ambassadors"],
+    "Community Operations": ["commops"],
     "Design": ["fedora-design"],
     "Documentation": ["fedora-docs"],
     "Engineering Leadership": ["fesco"],
@@ -7,7 +8,7 @@
     "Globalization": ["g11n"],
     "Infrastructure": ["infrastructure", "#fedora-apps", "#fedora-admin"],
     "Internationalization": ["i18n"],
-    "Marketing": ["fedora-mktg"],
+    "Marketing": ["fedora-mktg", "magazine"],
     "Packaging": ["fpc"],
     "Project Leadership": ["board", "council"],
     "Quality Assurance": ["fedora-qa"],

--- a/category_mappings.json
+++ b/category_mappings.json
@@ -10,7 +10,7 @@
     "Internationalization": ["i18n"],
     "Marketing": ["fedora-mktg", "magazine"],
     "Packaging": ["fpc"],
-    "Project Leadership": ["board", "council"],
+    "Project Leadership": ["council"],
     "Quality Assurance": ["fedora-qa"],
     "Release Engineering": ["releng"],
     "Websites": ["fedora-websites"]

--- a/name_mappings.json
+++ b/name_mappings.json
@@ -3,6 +3,10 @@
         "friendly-name": "The Fedora Board (archived)",
         "aliases": []
     },
+    "emea": {
+        "friendly-name": "Fedora Europe, Middle East, and Africa (EMEA) Ambassadors",
+        "aliases": ["emea", "emea_ambassadors", "emea-ambassadors"]
+    },
     "epel": {
         "friendly-name": "Extra Packages for Enterprise Linux",
         "aliases": []

--- a/name_mappings.json
+++ b/name_mappings.json
@@ -63,6 +63,10 @@
         "friendly-name": "Fedora Infrastructure Team",
         "aliases": ["fedora-infrastructure", "fedora_infrastructure", "#fedora-apps", "#fedora-admin"]
     },
+    "magazine": {
+        "friendly-name": "Fedora Magazine Editorial Board",
+        "aliases": ["magazine", "magazine_editorial_board", "fedora_magazine"]
+    },
     "releng": {
         "friendly-name": "Fedora Release Engineering (releng)",
         "aliases": []

--- a/name_mappings.json
+++ b/name_mappings.json
@@ -1,38 +1,26 @@
 {
-    "famna": {
-        "friendly-name": "Fedora North American Ambassadors",
+    "board": {
+        "friendly-name": "The Fedora Board",
         "aliases": []
-    },
-    "infrastructure": {
-        "friendly-name": "Fedora Infrastructure Team",
-        "aliases": ["fedora-infrastructure", "fedora_infrastructure", "#fedora-apps", "#fedora-admin"]
-    },
-    "fedora-design": {
-        "friendly-name": "Fedora Design Team",
-        "aliases": ["fedora-design", "designteam", "#fedora-design"]
     },
     "epel": {
         "friendly-name": "Extra Packages for Enterprise Linux",
         "aliases": []
     },
-    "fedora-mktg": {
-        "friendly-name": "Fedora Marketing",
+    "famna": {
+        "friendly-name": "Fedora North American Ambassadors",
         "aliases": []
+    },
+    "fedora-design": {
+        "friendly-name": "Fedora Design Team",
+        "aliases": ["fedora-design", "designteam", "#fedora-design"]
     },
     "fedora-docs": {
         "friendly-name": "Fedora Docs Team",
         "aliases": []
     },
-    "g11n": {
-        "friendly-name": "Fedora g11n Team",
-        "aliases": ["fedora-g11n", "fedora-globalization", "#fedora-g11n"]
-    },
-    "i18n": {
-        "friendly-name": "Fedora i18n Team",
-        "aliases": []
-    },
-    "fpc": {
-        "friendly-name": "Fedora Packaging Committee (FPC)",
+    "fedora-mktg": {
+        "friendly-name": "Fedora Marketing",
         "aliases": []
     },
     "fedora-qa": {
@@ -43,16 +31,28 @@
         "friendly-name": "Fedora Websites Team",
         "aliases": []
     },
-    "releng": {
-        "friendly-name": "Fedora Release Engineering (releng)",
+    "fpc": {
+        "friendly-name": "Fedora Packaging Committee (FPC)",
         "aliases": []
     },
     "fesco": {
         "friendly-name": "Fedora Engineering Steering Committee (FESCo)",
         "aliases": []
     },
-    "board": {
-        "friendly-name": "The Board",
+    "g11n": {
+        "friendly-name": "Fedora G11n Team",
+        "aliases": ["fedora-g11n", "fedora-globalization", "#fedora-g11n"]
+    },
+    "i18n": {
+        "friendly-name": "Fedora i18n Team",
+        "aliases": []
+    },
+    "infrastructure": {
+        "friendly-name": "Fedora Infrastructure Team",
+        "aliases": ["fedora-infrastructure", "fedora_infrastructure", "#fedora-apps", "#fedora-admin"]
+    },
+    "releng": {
+        "friendly-name": "Fedora Release Engineering (releng)",
         "aliases": []
     }
 }

--- a/name_mappings.json
+++ b/name_mappings.json
@@ -1,8 +1,4 @@
 {
-    "board": {
-        "friendly-name": "The Fedora Board (archived)",
-        "aliases": []
-    },
     "emea": {
         "friendly-name": "Fedora Europe, Middle East, and Africa (EMEA) Ambassadors",
         "aliases": ["emea", "emea_ambassadors", "emea-ambassadors"]
@@ -21,7 +17,7 @@
     },
     "fedora-council": {
         "friendly-name": "Fedora Council",
-        "aliases": ["council"]
+        "aliases": ["council", "board"]
     },
     "fedora-design": {
         "friendly-name": "Fedora Design Team",

--- a/name_mappings.json
+++ b/name_mappings.json
@@ -1,6 +1,6 @@
 {
     "board": {
-        "friendly-name": "The Fedora Board",
+        "friendly-name": "The Fedora Board (archived)",
         "aliases": []
     },
     "epel": {
@@ -10,6 +10,14 @@
     "famna": {
         "friendly-name": "Fedora North American Ambassadors",
         "aliases": []
+    },
+    "fedora-commops": {
+        "friendly-name": "Fedora Community Operations (CommOps)",
+        "aliases": ["commops", "CommOps", "community-operations", "community_operations"]
+    },
+    "fedora-council": {
+        "friendly-name": "Fedora Council",
+        "aliases": ["council"]
     },
     "fedora-design": {
         "friendly-name": "Fedora Design Team",


### PR DESCRIPTION
Copy and pasted from commit:
This commit removes official mention of the Fedora Board from møte as it is now defunct in lieu of the new Fedora Council. Since the Council replaces the Board, the name mapping for the Fedora Council includes the keyword for the Fedora Board, so all of the previous meetings in the history of the upper-level deciding body of Fedora are grouped and clustered together.

This aims to make it easier to search and navigate through older and current meetings relating to higher-level Fedora leadership.