### PR TITLE
Fix regex to catch correct segment of filename

### DIFF
--- a/mote/soke.py
+++ b/mote/soke.py
@@ -44,7 +44,7 @@ def memcached_dict_add(dictn, key, val):
 
 def get_date_fn(filename):
     # Return a meeting's date from a filename.
-    m = re.search(".*?[\-\.]([0-9]{4}\-[0-9]{2}\-[0-9]{2})[\-\.].*", filename)
+    m = re.search(".*[\-\.]([0-9]{4}\-[0-9]{2}\-[0-9]{2})[\-\.][0-9]{2}\.[0-9]{2}\.(html|log\.html|txt|log\.txt)", filename)
     if m == None:
         raise ValueError("Failed to parse date from %r" % filename)
     return m.group(1)


### PR DESCRIPTION
This issue was noted by `robyduck` on IRC. 
Specifically, this team was not showing up in search due to its symbols in its filename. 

See https://meetbot.fedoraproject.org/sresults/?group_id=fedora-it_-_incontro_periodico_della_comunita_italiana&type=team

However, it seems like it is now showing up through search. @puiterwijk, did you launch a hotfix to fix this or did it fix itself?

This patch loosens certain aspects of the regex and adds better heuristics for the filename ending, to prevent filenames with `-` symbols from interfering with the date and file extension detection mechanisms.