### PR TITLE
Fix #83, fetch from channel whenever possible for single logs

### DIFF
--- a/mote/__init__.py
+++ b/mote/__init__.py
@@ -254,7 +254,6 @@ def get_meeting_log():
 
     url = config.meetbot_fetch_prefix + link_prefix_ending + file_name
 
-    print url
     try:
         fetch_result = requests.get(url)
         fetch_soup = BeautifulSoup(fetch_result.text)

--- a/mote/__init__.py
+++ b/mote/__init__.py
@@ -127,7 +127,7 @@ def handle_meeting_date_request(group_type, meeting_group, date_stamp):
             type=group_type,
             group_name=meeting_group
         )
-    except:
+    except KeyError:
         raise ValueError("Meetings unable to be located.")
 
 @app.route('/', methods=['GET'])


### PR DESCRIPTION
 - Whenever the channel name is provided when requesting single logs, attempt to fetch based on the meeting channel rather than the team name.
 - Remove redundancy associated with meeting date requests