### PR TITLE
Add new fedora-mktg alias

### DIFF
--- a/name_mappings.json
+++ b/name_mappings.json
@@ -33,7 +33,7 @@
     },
     "fedora-mktg": {
         "friendly-name": "Fedora Marketing",
-        "aliases": []
+        "aliases": ["marketing"]
     },
     "fedora-qa": {
         "friendly-name": "Fedora QA",


### PR DESCRIPTION
Adds a new alias for the `fedora-mktg` team. Ran the tests script and all checked out.