### PR TITLE
Output traceback from 500 handled errors onto stderr

### DIFF
--- a/mote/__init__.py
+++ b/mote/__init__.py
@@ -29,6 +29,7 @@ except:
 
 import flask, random, string, json, util, re
 import dateutil.parser, requests, collections
+import logging
 
 from six.moves import html_parser as html_parser_six
 
@@ -68,6 +69,9 @@ else:
 name_mappings = map_name_aliases(json.loads(name_mappings))
 category_mappings = json.loads(category_mappings)
 
+logging_format = '%(asctime)-15s %(message)s'
+logging.basicConfig(format=logging_format)
+logger = logging.getLogger('tcpserver')
 
 if config.use_memcached == True:
     import memcache

--- a/mote/__init__.py
+++ b/mote/__init__.py
@@ -71,7 +71,7 @@ category_mappings = json.loads(category_mappings)
 
 logging_format = '%(asctime)-15s %(message)s'
 logging.basicConfig(format=logging_format)
-logger = logging.getLogger('tcpserver')
+logger = logging.getLogger(__name__)
 
 if config.use_memcached == True:
     import memcache


### PR DESCRIPTION
Uses the traceback module to output Flask's caught errors onto `stderr`.