### PR TITLE
Add / standardize Ambassadors, swap Marketing names

### DIFF
--- a/category_mappings.json
+++ b/category_mappings.json
@@ -1,5 +1,5 @@
 {
-    "Ambassadors": ["famna", "emea_ambassadors", "fedora-latam", "#fedora-ambassadors"],
+    "Ambassadors": ["apac", "emea_ambassadors", "famna", "fedora-latam", "#fedora-ambassadors"],
     "Community Operations": ["commops"],
     "Design": ["fedora-design", "badges"],
     "Documentation": ["fedora-docs"],

--- a/name_mappings.json
+++ b/name_mappings.json
@@ -1,14 +1,18 @@
 {
-	"badges": {
-		"friendly-name": "Fedora Badges Team",
-		"aliases": ["fedora_badges", "fedbadges", "badges_team", "fedora_badges_team"]
-	},
+    "apac" : {
+        "friendly-name": "APAC Ambassadors (Asia-Pacific)",
+        "aliases": ["apac-special-meeting", "apac_special_meeting"]
+    },
+    "badges": {
+        "friendly-name": "Fedora Badges Team",
+        "aliases": ["fedora_badges", "fedbadges", "badges_team", "fedora_badges_team"]
+    },
     "commops": {
         "friendly-name": "Fedora Community Operations (CommOps)",
         "aliases": ["fedora_commops"]
     },
     "emea_ambassadors": {
-        "friendly-name": "Fedora Europe, Middle East, and Africa (EMEA) Ambassadors",
+        "friendly-name": "EMEA Ambassadors (Europe, Middle East, and Africa)",
         "aliases": ["emea"]
     },
     "epel": {
@@ -16,7 +20,7 @@
         "aliases": []
     },
     "famna": {
-        "friendly-name": "Fedora North American Ambassadors",
+        "friendly-name": "NA Ambassadors (North America)",
         "aliases": []
     },
     "fedora_council": {
@@ -32,12 +36,12 @@
         "aliases": []
     },
     "fedora-latam": {
-    	"friendly-name": "Fedora Latin American Ambassadors",
+    	"friendly-name": "LATAM Ambassadors (Latin America)",
     	"aliases": ["fedora_latam_meeting", "fedora_latam", "fedora_latam_ambassadors", "fedora_latam_ambassadors_meeting", "latam_ambassadors", "latam_ambassadors_meeting", "ambassadors_latam", "fedora_ambassadors_latam", "latam"]
     },
-    "fedora-mktg": {
+    "marketing": {
         "friendly-name": "Fedora Marketing",
-        "aliases": ["marketing"]
+        "aliases": ["fedora-mktg"]
     },
     "fedora-qa": {
         "friendly-name": "Fedora QA",


### PR DESCRIPTION
This commit does a couple of things:

* Adds the APAC Ambassadors to the Meetbot teams page for improved accessibility
* Changes the friendly names of all Ambassadors to be a little more consistent (i.e. `"[region] Ambassadors ([full region name])`")
* Swaps the Marketing meetings to use `marketing` as the primary meeting name, `fedora-mktg` as the alias
  * The Marketing team hasn't met under the name `fedora-mktg` for a few years

----

cc: @sachinkamath