### PR TITLE
improve instruction on how to install the package, fixes #119

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Dependencies:
  - Optional: `memcached` (`sudo dnf install memcached`)
  - Python 2.7.x
 
-`pip` Dependencies:
+Installation:
+ - Optional: create virtual environment
+ - pip install -r requirements.txt
  - Install using `python setup.py develop`
 
 Running møte:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Dependencies:
 
 Installation:
  - Optional: create virtual environment
- - pip install -r requirements.txt
+ - `pip install -r requirements.txt`
  - Install using `python setup.py develop`
 
 Running møte:


### PR DESCRIPTION
This commit tries to improve the instruction on how to install mote, making it clear that packages on `requirements.txt` must be installed beforehand.