### PR TITLE
Fix syntax highliting in meeting logs

### DIFF
--- a/mote/static/js/sresults.js
+++ b/mote/static/js/sresults.js
@@ -47,7 +47,7 @@ function openLogModal(fname, prefix_ending) {
               <h4 class="modal-title inline" id="modalLabel">#{title}</h4>\
               <a target="_blank" class="btn btn-info btn-sm modal-button pull-right" href="#{permalink}">Permalink</a>\
             </div>\
-            <div class="modal-body logdisplay">\
+            <div class="modal-body log-display">\
               #{body}\
             </div>\
             <div class="modal-footer">\


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/27789806/75189952-ec154200-5714-11ea-8a4c-d57afa9071a9.png) | ![image](https://user-images.githubusercontent.com/27789806/75190010-0cdd9780-5715-11ea-8bbf-f2f6fde254bb.png) |

