### PR TITLE
ci: Modernize Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,21 @@
-language: python
-python:
-  - "3.8"
-# command to install dependencies
-install: "pip install -r requirements.txt"
-# command to run tests
-script: sh run_tests.sh
+---
+os: linux
+dist: bionic
+
+jobs:
+  include:
+    - language: python
+      python: 3.8
+      cache: pip
+      install: "pip install -r requirements.txt"
+      script: sh run_tests.sh
 
 notifications:
-  email: false
+  irc:
+    channels:
+      - "ircs://chat.freenode.net:6697/#fedora-apps"
+      - "ircs://chat.freenode.net:6697/#fedora-mote"
+    template:
+      - "[%{repository_name}:%{branch}@%{commit} - build #%{build_number}] CI %{result}! (%{build_url})"
+    on_success: change
+    on_failure: always


### PR DESCRIPTION
This commit reworks the Travis CI config to run in a more modern
environment. The original Travis file is carried over for many years. In
short, this commit does the following:

* Bumps build env from Ubuntu Xenial to Ubuntu Bionic
* Utilizes pip caching for faster build times
* Sends status notifications to `#fedora-mote` on Freenode IRC