### PR TITLE
Pipfile: Upgrade env to Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: bionic
 jobs:
   include:
     - language: python
-      python: 3.8
+      python: 3.9
       cache: pip
       install: "pip install -r requirements.txt"
       script: sh run_tests.sh

--- a/Pipfile
+++ b/Pipfile
@@ -28,4 +28,4 @@ Jinja2 = ">=2.7.3"
 python3-openid = ">=3.2.0"
 
 [requires]
-python_version = "3.8"
+python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e8a07cd88373375e43e295411f4d152ce0f3419ee06fa2ef2b206af6f8527e20"
+            "sha256": "fc94cc73caaa4811773d3b3e39869d039d3e658fdf0f73eb62a24488f9b93037"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.8"
+            "python_version": "3.9"
         },
         "sources": [
             {
@@ -52,6 +52,7 @@
                 "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
                 "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==7.1.2"
         },
         "defusedxml": {
@@ -59,6 +60,7 @@
                 "sha256:6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93",
                 "sha256:f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.6.0"
         },
         "flask": {
@@ -74,6 +76,7 @@
                 "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
                 "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
         "itsdangerous": {
@@ -247,11 +250,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
-                "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
+                "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
+                "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
             ],
             "index": "pypi",
-            "version": "==1.25.10"
+            "version": "==1.25.11"
         },
         "werkzeug": {
             "hashes": [


### PR DESCRIPTION
This commit raises Møte's supported Python version to Python 3.9. In the
upcoming Fedora 33 release, Fedora 3.9 becomes the default version of
the Python interpreter. So, this follows Fedora's precedent by using the
latest version of upstream Python.

Since we are still early in development, we can be more flexible about
this for now.

Part of #126, but does not complete it.