### PR TITLE
Version bumped flask to 1.1.2

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ verify_ssl = true
 [packages]
 arrow = ">=0.7.0"
 beautifulsoup4 = ">=4.3.2"
-flask = ">=0.10.1"
+flask = ">=1.1.2"
 itsdangerous = ">=0.24"
 kitchen = ">=1.2.1"
 markupsafe = ">=0.23"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fc94cc73caaa4811773d3b3e39869d039d3e658fdf0f73eb62a24488f9b93037"
+            "sha256": "faf77f5e5b23aec1fb2f73b4415b3450d4fdfe39d6755441621a7a0660375706"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -52,7 +52,6 @@
                 "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
                 "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==7.1.2"
         },
         "defusedxml": {
@@ -60,7 +59,6 @@
                 "sha256:6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93",
                 "sha256:f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.6.0"
         },
         "flask": {
@@ -76,7 +74,6 @@
                 "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
                 "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
         "itsdangerous": {
@@ -189,10 +186,10 @@
         },
         "python-fedora": {
             "hashes": [
-                "sha256:efb675929ebf588c2deffa2058ff407e65d1889bca1b545a58f525135367c9e4"
+                "sha256:8cca046074001cedec0f7af5f80b288ff588c596fa1d4ff983251984e9b4fcaa"
             ],
             "index": "pypi",
-            "version": "==1.0.0"
+            "version": "==1.1.0"
         },
         "python-memcached": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e8a07cd88373375e43e295411f4d152ce0f3419ee06fa2ef2b206af6f8527e20"
+            "sha256": "9c30b6bca7ddb4be00f25a7939c8afd47a9c47a1916654eb4af0523fb3485638"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -247,11 +247,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
-                "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
+                "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
+                "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
             ],
             "index": "pypi",
-            "version": "==1.25.10"
+            "version": "==1.25.11"
         },
         "werkzeug": {
             "hashes": [


### PR DESCRIPTION
Version Bumping from flask 0.10.1 to 1.1.2 to make sure to work on the latest framework and use it's functionalities.

Ticket: https://github.com/fedora-infra/mote/issues/138

cc: @HiraTariq-01 