### PR TITLE
wrap text properly in log display

### DIFF
--- a/mote/static/css/mote.css
+++ b/mote/static/css/mote.css
@@ -54,7 +54,7 @@
   width: 80%;
 }
 
-.log-display pre { white-space: pre-wrap; }
+.log-display pre { white-space: pre-wrap; word-break: keep-all; }
 .log-display pre { background: #f0f0f0; }
 
 .log-display pre .tm  { color: #007020 }                      /* time */


### PR DESCRIPTION
This PR is for [issue#62](https://github.com/fedora-infra/mote/issues/62) to fix the word wrapping issue.