### PR TITLE
Fixes Issue #174: Add CI for enforcing styles with Black and sorting imports 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+name: run black and isort
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install isort and black
+        run: pip install isort black
+      - name: Run isort
+        run: isort --check --diff .
+      - name: Run black
+        run: black --check --diff .


### PR DESCRIPTION
## Description
Added a custom GitHub workflow to enforce coding style with black and to sort imports using isort. This workflow triggers on all push and pull requests. It sets up a python 3.8 environment and runs both black and isort on the codebase starting from the root directory. The verbose output of both isort and black can be checked in the GitHub actions log and changes can be introduced with respect to that.

Fixes #174 