### PR TITLE
Separate the configuration in env files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+BASE_URL="https://apps.fedoraproject.org"
+TOPIC="org.fedoraproject.prod.meetbot.meeting.complete"
+MEETBOT="https://meetbot.fedoraproject.org"

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-BASE_URL="https://apps.fedoraproject.org"
+APP_URL="https://apps.fedoraproject.org"
 TOPIC="org.fedoraproject.prod.meetbot.meeting.complete"
-MEETBOT="https://meetbot.fedoraproject.org"
+BASE_URL="https://meetbot.fedoraproject.org"

--- a/modules/config.py
+++ b/modules/config.py
@@ -3,6 +3,6 @@ import os
 from dotenv import load_dotenv
 load_dotenv()
 
-BASE_URL = os.environ["BASE_URL"]
+APP_URL = os.environ["APP_URL"]
 TOPIC = os.environ["TOPIC"]
-MEETBOT = os.environ["MEETBOT"]
+BASE_URL = os.environ["BASE_URL"]

--- a/modules/config.py
+++ b/modules/config.py
@@ -1,0 +1,8 @@
+import os
+
+from dotenv import load_dotenv
+load_dotenv()
+
+BASE_URL = os.environ["BASE_URL"]
+TOPIC = os.environ["TOPIC"]
+MEETBOT = os.environ["MEETBOT"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4>=4.0.0
 Flask>=2.0.0
+python-dotenv==0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 beautifulsoup4>=4.0.0
 Flask>=2.0.0
-python-dotenv==0.12.0

--- a/src/mote/configs/config.py
+++ b/src/mote/configs/config.py
@@ -1,9 +1,6 @@
-import os
-
-from dotenv import load_dotenv
-load_dotenv()
-
-APP_URL = os.environ["APP_URL"]
-TOPIC = os.environ["TOPIC"]
-BASE_URL = os.environ["BASE_URL"]
+configuration = dict(
+    app_url = "https://apps.fedoraproject.org",
+    topic = "org.fedoraproject.prod.meetbot.meeting.complete",
+    base_url = "https://meetbot.fedoraproject.org"
+)
     

--- a/src/mote/configs/config.py
+++ b/src/mote/configs/config.py
@@ -6,3 +6,4 @@ load_dotenv()
 APP_URL = os.environ["APP_URL"]
 TOPIC = os.environ["TOPIC"]
 BASE_URL = os.environ["BASE_URL"]
+    

--- a/src/mote/modules/call.py
+++ b/src/mote/modules/call.py
@@ -26,7 +26,7 @@ import urllib.parse as ulpr
 
 import bs4 as btsp
 
-from config import MEETBOT
+from config import BASE_URL
 
 recognition_pattern = "(.*)[\-\.]([0-9]{4}-[0-9]{2}-[0-9]{2})-([0-9]{2}\.[0-9]{2})"
 
@@ -36,7 +36,7 @@ def fetch_channel_dict():
         channel_dict = {}
         chanlist = os.listdir("/srv/web/meetbot")
         for channel in chanlist:
-            channel_dict[channel] = MEETBOT + "/%s" % channel
+            channel_dict[channel] = BASE_URL + "/%s" % channel
         return True, channel_dict
     except Exception as expt:
         return False, {"exception": str(expt)}
@@ -47,7 +47,7 @@ def fetch_datetxt_dict(channel: str):
         datetxt_dict = {}
         datelist = os.listdir("/srv/web/meetbot/%s" % channel)
         for datetxt in datelist:
-            datetxt_dict[datetxt] = MEETBOT + "/%s/%s" % (
+            datetxt_dict[datetxt] = BASE_URL + "/%s/%s" % (
                 channel,
                 datetxt,
             )
@@ -62,12 +62,12 @@ def fetch_meeting_dict(channel: str, datetxt: str):
         meetlist = os.listdir("/srv/web/meetbot/%s/%s" % (channel, datetxt))
         for meeting in meetlist:
             if ".log.html" in meeting:
-                meeting_log = MEETBOT + "/%s/%s/%s" % (
+                meeting_log = BASE_URL + "/%s/%s/%s" % (
                     channel,
                     datetxt,
                     meeting,
                 )
-                meeting_sum = MEETBOT + "/%s/%s/%s" % (
+                meeting_sum = BASE_URL + "/%s/%s/%s" % (
                     channel,
                     datetxt,
                     meeting.replace(".log.html", ".html"),
@@ -88,13 +88,13 @@ def fetch_meeting_dict(channel: str, datetxt: str):
                     "slug": {
                         "logs": ulpr.quote(
                             meeting_log.replace(
-                                MEETBOT, ""
+                                BASE_URL, ""
                             ),
                             safe=":/?",
                         ),
                         "summary": ulpr.quote(
                             meeting_sum.replace(
-                                MEETBOT, ""
+                                BASE_URL, ""
                             ),
                             safe=":/?",
                         ),

--- a/src/mote/modules/call.py
+++ b/src/mote/modules/call.py
@@ -26,7 +26,7 @@ import urllib.parse as ulpr
 
 import bs4 as btsp
 
-from mote.configs.config import BASE_URL
+from mote.configs.config import configuration
 
 recognition_pattern = "(.*)[\-\.]([0-9]{4}-[0-9]{2}-[0-9]{2})-([0-9]{2}\.[0-9]{2})"
 
@@ -36,7 +36,7 @@ def fetch_channel_dict():
         channel_dict = {}
         chanlist = os.listdir("/srv/web/meetbot")
         for channel in chanlist:
-            channel_dict[channel] = BASE_URL + "/%s" % channel
+            channel_dict[channel] = configuration.base_url + "/%s" % channel
         return True, channel_dict
     except Exception as expt:
         return False, {"exception": str(expt)}
@@ -47,7 +47,7 @@ def fetch_datetxt_dict(channel: str):
         datetxt_dict = {}
         datelist = os.listdir("/srv/web/meetbot/%s" % channel)
         for datetxt in datelist:
-            datetxt_dict[datetxt] = BASE_URL + "/%s/%s" % (
+            datetxt_dict[datetxt] = configuration.base_url + "/%s/%s" % (
                 channel,
                 datetxt,
             )
@@ -62,12 +62,12 @@ def fetch_meeting_dict(channel: str, datetxt: str):
         meetlist = os.listdir("/srv/web/meetbot/%s/%s" % (channel, datetxt))
         for meeting in meetlist:
             if ".log.html" in meeting:
-                meeting_log = BASE_URL + "/%s/%s/%s" % (
+                meeting_log = configuration.base_url + "/%s/%s/%s" % (
                     channel,
                     datetxt,
                     meeting,
                 )
-                meeting_sum = BASE_URL + "/%s/%s/%s" % (
+                meeting_sum = configuration.base_url + "/%s/%s/%s" % (
                     channel,
                     datetxt,
                     meeting.replace(".log.html", ".html"),
@@ -88,13 +88,13 @@ def fetch_meeting_dict(channel: str, datetxt: str):
                     "slug": {
                         "logs": ulpr.quote(
                             meeting_log.replace(
-                                BASE_URL, ""
+                                configuration.base_url, ""
                             ),
                             safe=":/?",
                         ),
                         "summary": ulpr.quote(
                             meeting_sum.replace(
-                                BASE_URL, ""
+                                configuration.base_url, ""
                             ),
                             safe=":/?",
                         ),

--- a/src/mote/modules/call.py
+++ b/src/mote/modules/call.py
@@ -26,6 +26,8 @@ import urllib.parse as ulpr
 
 import bs4 as btsp
 
+from config import MEETBOT
+
 recognition_pattern = "(.*)[\-\.]([0-9]{4}-[0-9]{2}-[0-9]{2})-([0-9]{2}\.[0-9]{2})"
 
 
@@ -34,7 +36,7 @@ def fetch_channel_dict():
         channel_dict = {}
         chanlist = os.listdir("/srv/web/meetbot")
         for channel in chanlist:
-            channel_dict[channel] = "https://meetbot-raw.fedoraproject.org/%s" % channel
+            channel_dict[channel] = MEETBOT + "/%s" % channel
         return True, channel_dict
     except Exception as expt:
         return False, {"exception": str(expt)}
@@ -45,7 +47,7 @@ def fetch_datetxt_dict(channel: str):
         datetxt_dict = {}
         datelist = os.listdir("/srv/web/meetbot/%s" % channel)
         for datetxt in datelist:
-            datetxt_dict[datetxt] = "https://meetbot-raw.fedoraproject.org/%s/%s" % (
+            datetxt_dict[datetxt] = MEETBOT + "/%s/%s" % (
                 channel,
                 datetxt,
             )
@@ -60,12 +62,12 @@ def fetch_meeting_dict(channel: str, datetxt: str):
         meetlist = os.listdir("/srv/web/meetbot/%s/%s" % (channel, datetxt))
         for meeting in meetlist:
             if ".log.html" in meeting:
-                meeting_log = "https://meetbot-raw.fedoraproject.org/%s/%s/%s" % (
+                meeting_log = MEETBOT + "/%s/%s/%s" % (
                     channel,
                     datetxt,
                     meeting,
                 )
-                meeting_sum = "https://meetbot-raw.fedoraproject.org/%s/%s/%s" % (
+                meeting_sum = MEETBOT + "/%s/%s/%s" % (
                     channel,
                     datetxt,
                     meeting.replace(".log.html", ".html"),
@@ -86,13 +88,13 @@ def fetch_meeting_dict(channel: str, datetxt: str):
                     "slug": {
                         "logs": ulpr.quote(
                             meeting_log.replace(
-                                "https://meetbot-raw.fedoraproject.org", ""
+                                MEETBOT, ""
                             ),
                             safe=":/?",
                         ),
                         "summary": ulpr.quote(
                             meeting_sum.replace(
-                                "https://meetbot-raw.fedoraproject.org", ""
+                                MEETBOT, ""
                             ),
                             safe=":/?",
                         ),

--- a/src/mote/modules/call.py
+++ b/src/mote/modules/call.py
@@ -26,7 +26,7 @@ import urllib.parse as ulpr
 
 import bs4 as btsp
 
-from config import BASE_URL
+from mote.configs.config import BASE_URL
 
 recognition_pattern = "(.*)[\-\.]([0-9]{4}-[0-9]{2}-[0-9]{2})-([0-9]{2}\.[0-9]{2})"
 

--- a/src/mote/modules/find.py
+++ b/src/mote/modules/find.py
@@ -25,7 +25,7 @@ import os
 import re
 import urllib.parse as ulpr
 
-from mote.configs.config import BASE_URL
+from mote.configs.config import configuration
 
 directory_path = os.path.dirname("/srv/web/meetbot/")
 recognition_pattern = "(.*)[\-\.]([0-9]{4}-[0-9]{2}-[0-9]{2})-([0-9]{2}\.[0-9]{2})"
@@ -65,13 +65,13 @@ def find_meetings_by_substring(search_string: str):
                                 "date": meeting_date,
                                 "time": meeting_title.group(3),
                                 "url": {
-                                    "logs": BASE_URL + "/%s/%s/%s"
+                                    "logs": configuration.base_url + "/%s/%s/%s"
                                     % (
                                         channel_name,
                                         meeting_date,
                                         meeting_log_filename,
                                     ),
-                                    "summary": BASE_URL + "/%s/%s/%s"
+                                    "summary": configuration.base_url + "/%s/%s/%s"
                                     % (
                                         channel_name,
                                         meeting_date,

--- a/src/mote/modules/find.py
+++ b/src/mote/modules/find.py
@@ -25,7 +25,7 @@ import os
 import re
 import urllib.parse as ulpr
 
-from config import MEETBOT
+from config import BASE_URL
 
 directory_path = os.path.dirname("/srv/web/meetbot/")
 recognition_pattern = "(.*)[\-\.]([0-9]{4}-[0-9]{2}-[0-9]{2})-([0-9]{2}\.[0-9]{2})"
@@ -65,13 +65,13 @@ def find_meetings_by_substring(search_string: str):
                                 "date": meeting_date,
                                 "time": meeting_title.group(3),
                                 "url": {
-                                    "logs": MEETBOT + "/%s/%s/%s"
+                                    "logs": BASE_URL + "/%s/%s/%s"
                                     % (
                                         channel_name,
                                         meeting_date,
                                         meeting_log_filename,
                                     ),
-                                    "summary": MEETBOT + "/%s/%s/%s"
+                                    "summary": BASE_URL + "/%s/%s/%s"
                                     % (
                                         channel_name,
                                         meeting_date,

--- a/src/mote/modules/find.py
+++ b/src/mote/modules/find.py
@@ -25,7 +25,7 @@ import os
 import re
 import urllib.parse as ulpr
 
-from config import BASE_URL
+from mote.configs.config import BASE_URL
 
 directory_path = os.path.dirname("/srv/web/meetbot/")
 recognition_pattern = "(.*)[\-\.]([0-9]{4}-[0-9]{2}-[0-9]{2})-([0-9]{2}\.[0-9]{2})"

--- a/src/mote/modules/find.py
+++ b/src/mote/modules/find.py
@@ -25,6 +25,8 @@ import os
 import re
 import urllib.parse as ulpr
 
+from config import MEETBOT
+
 directory_path = os.path.dirname("/srv/web/meetbot/")
 recognition_pattern = "(.*)[\-\.]([0-9]{4}-[0-9]{2}-[0-9]{2})-([0-9]{2}\.[0-9]{2})"
 
@@ -63,13 +65,13 @@ def find_meetings_by_substring(search_string: str):
                                 "date": meeting_date,
                                 "time": meeting_title.group(3),
                                 "url": {
-                                    "logs": "https://meetbot-raw.fedoraproject.org/%s/%s/%s"
+                                    "logs": MEETBOT + "/%s/%s/%s"
                                     % (
                                         channel_name,
                                         meeting_date,
                                         meeting_log_filename,
                                     ),
-                                    "summary": "https://meetbot-raw.fedoraproject.org/%s/%s/%s"
+                                    "summary": MEETBOT + "/%s/%s/%s"
                                     % (
                                         channel_name,
                                         meeting_date,

--- a/src/mote/modules/late.py
+++ b/src/mote/modules/late.py
@@ -24,13 +24,15 @@ import json
 import urllib.request as ulrq
 from time import ctime
 
+from config import BASE_URL,TOPIC,MEETBOT
+
 seconds_delta = 86400
 
 
 def fetch_recent_meetings(days):
     try:
-        datagrepper_base_url = "https://apps.fedoraproject.org"
-        topic = "org.fedoraproject.prod.meetbot.meeting.complete"
+        datagrepper_base_url = BASE_URL
+        topic = TOPIC
         source = "{}/datagrepper/raw?delta={}&topic={}".format(
             datagrepper_base_url, days * seconds_delta, topic
         )
@@ -40,11 +42,11 @@ def fetch_recent_meetings(days):
         for indx in meeting_rawlist:
             data = indx["msg"]
             logs_url = (
-                data["url"].replace("https://meetbot.fedoraproject.org", "")
+                data["url"].replace(MEETBOT, "")
                 + ".log.html"
             )
             summary_url = (
-                data["url"].replace("https://meetbot.fedoraproject.org", "") + ".html"
+                data["url"].replace(MEETBOT, "") + ".html"
             )
             meeting_dict[data["details"]["time_"]] = {
                 "topic": data["meeting_topic"],

--- a/src/mote/modules/late.py
+++ b/src/mote/modules/late.py
@@ -24,7 +24,7 @@ import json
 import urllib.request as ulrq
 from time import ctime
 
-from config import APP_URL,TOPIC,BASE_URL
+from mote.configs.config import APP_URL,TOPIC,BASE_URL
 
 seconds_delta = 86400
 

--- a/src/mote/modules/late.py
+++ b/src/mote/modules/late.py
@@ -24,14 +24,14 @@ import json
 import urllib.request as ulrq
 from time import ctime
 
-from config import BASE_URL,TOPIC,MEETBOT
+from config import APP_URL,TOPIC,BASE_URL
 
 seconds_delta = 86400
 
 
 def fetch_recent_meetings(days):
     try:
-        datagrepper_base_url = BASE_URL
+        datagrepper_base_url = APP_URL
         topic = TOPIC
         source = "{}/datagrepper/raw?delta={}&topic={}".format(
             datagrepper_base_url, days * seconds_delta, topic
@@ -42,11 +42,11 @@ def fetch_recent_meetings(days):
         for indx in meeting_rawlist:
             data = indx["msg"]
             logs_url = (
-                data["url"].replace(MEETBOT, "")
+                data["url"].replace(BASE_URL, "")
                 + ".log.html"
             )
             summary_url = (
-                data["url"].replace(MEETBOT, "") + ".html"
+                data["url"].replace(BASE_URL, "") + ".html"
             )
             meeting_dict[data["details"]["time_"]] = {
                 "topic": data["meeting_topic"],

--- a/src/mote/modules/late.py
+++ b/src/mote/modules/late.py
@@ -24,15 +24,15 @@ import json
 import urllib.request as ulrq
 from time import ctime
 
-from mote.configs.config import APP_URL,TOPIC,BASE_URL
+from mote.configs.config import configuration
 
 seconds_delta = 86400
 
 
 def fetch_recent_meetings(days):
     try:
-        datagrepper_base_url = APP_URL
-        topic = TOPIC
+        datagrepper_base_url = configuration.app_url
+        topic = configuration.topic
         source = "{}/datagrepper/raw?delta={}&topic={}".format(
             datagrepper_base_url, days * seconds_delta, topic
         )
@@ -42,11 +42,11 @@ def fetch_recent_meetings(days):
         for indx in meeting_rawlist:
             data = indx["msg"]
             logs_url = (
-                data["url"].replace(BASE_URL, "")
+                data["url"].replace(configuration.base_url, "")
                 + ".log.html"
             )
             summary_url = (
-                data["url"].replace(BASE_URL, "") + ".html"
+                data["url"].replace(configuration.base_url, "") + ".html"
             )
             meeting_dict[data["details"]["time_"]] = {
                 "topic": data["meeting_topic"],


### PR DESCRIPTION
This is based on issue #180 

A env file has made used to specify the configuration details for the application

python dotenv is used for reading the configs from a .env and used in respective areas of the codebase

sample .env.example has been added to the repository with the previous values 

requirements.txt has been updated 