### PR TITLE
Updated dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 venv/**
+meetbot
+meetbot.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,7 @@ COPY . /opt/app
 LABEL maintainer "Anurag Phadnis <phadnis.anurag@gmail.com>"
 WORKDIR /opt/app
 RUN pip3 install -r requirements.txt
-ENTRYPOINT ["python3", "main.py"]
+RUN python setup.py install
+EXPOSE 9696/tcp
+ENTRYPOINT ["start-mote-server"]
 CMD ["-p 9696", "-4"]


### PR DESCRIPTION
How to use this container image:

0. install podman 
   `dnf install podman` on Fedora
   `apt-get install podman` on Ubuntu
1. Clone this repository 
   `git clone git@github.com:fedora-infra/mote.git`
2. Go inside
   `cd mote`
3. Download the meetbot archive (see link in README.md) and save it inside the `mote` directory
4. Extract it 
   `tar xzf meetbot.tar.gz`
5. Build the container image
   `podman build -t mote .`
6. Then run it
   `podman run -it --rm -p9696:9696 -v ./meetbot:/srv/web/meetbot:Z mote`
7. Go to http://localhost:9696