### PR TITLE
remove unused ctime import

### DIFF
--- a/src/mote/modules/late.py
+++ b/src/mote/modules/late.py
@@ -23,7 +23,6 @@
 import json
 import urllib.request as ulrq
 from datetime import datetime
-from time import ctime
 
 seconds_delta = 86400
 


### PR DESCRIPTION
With reference to PR #200 `ctime` is no longer being used in `late.py` and hence is redundant and should be removed.

@darknao @t0xic0der 