### PR TITLE
Refactored hyperlinks in topbar

### DIFF
--- a/src/mote/templates/e404page.html
+++ b/src/mote/templates/e404page.html
@@ -31,7 +31,7 @@
                     <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                     </ul>
                     <div class="d-flex">
-                        <a class="text-white" href="https://getfedora.org/" target="_blank" type="button">Get Fedora</a>
+                        <a class="text-white;" style="margin-top: 4px;" href="https://getfedora.org/" target="_blank" type="button">Get Fedora</a>
                     </div>
                 </div>
             </div>

--- a/src/mote/templates/mainpage.html
+++ b/src/mote/templates/mainpage.html
@@ -50,19 +50,10 @@
                 </button>
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
                     <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                        <li class="nav-item">
-                            <a class="nav-link"
-                               aria-current="page"
-                               data-bs-toggle="modal"
-                               data-bs-target="#chanmode"
-                               type="button"
-                               onclick="populate_channel_list();">
-                                Channels
-                            </a>
-                        </li>
+                        <li class="nav-item"></li>
                     </ul>
                     <div class="d-flex">
-                        <a style="color:#676767; text-decoration:none;" href="https://getfedora.org/" target="_blank" type="button">Get Fedora</a>
+                        <a style="color:#676767; text-decoration:none; margin-top: 4px;" href="https://getfedora.org/" target="_blank" type="button">Get Fedora</a>
                     </div>
                 </div>
             </div>

--- a/src/mote/templates/statfile.html
+++ b/src/mote/templates/statfile.html
@@ -50,7 +50,7 @@
                         <li class="nav-item"></li>
                     </ul>
                     <form class="d-flex">
-                        <a style="color:#676767; text-decoration:none;" href="https://getfedora.org/" target="_blank" type="button">Get Fedora</a>
+                        <a style="color:#676767; text-decoration:none; margin-top: 4px;" href="https://getfedora.org/" target="_blank" type="button">Get Fedora</a>
                     </form>
                 </div>
             </div>


### PR DESCRIPTION
* Removed the `Channel` hyperlink from the top bar as suggested by @darknao in issue #206 
* Aligned the position of the `Get Fedora` hyperlink which is now perfectly in line with the `Fragment` logo.

Closes #206 

@darknao @t0xic0der Please review