### PR TITLE
Implement Fedora messaging notifications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
-FROM python:3.8-alpine
-COPY . /opt/app
-LABEL maintainer "Anurag Phadnis <phadnis.anurag@gmail.com>"
+FROM registry.fedoraproject.org/fedora-minimal
+RUN microdnf install -y python util-linux && microdnf clean all
+ADD https://github.com/fedora-infra/fedora-messaging/raw/stable/configs/cacert.pem /etc/fedora-messaging/
+ADD https://github.com/fedora-infra/fedora-messaging/raw/stable/configs/fedora-cert.pem /etc/fedora-messaging/
+ADD https://github.com/fedora-infra/fedora-messaging/raw/stable/configs/fedora-key.pem /etc/fedora-messaging/
 WORKDIR /opt/app
+COPY requirements.txt /opt/app
 RUN pip3 install -r requirements.txt
-RUN python setup.py install
+COPY src /opt/app
+COPY fedora-messaging.toml /etc/fedora-messaging/config.toml
+RUN sed -ie "s/[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}/$(uuidgen)/g" \
+    /etc/fedora-messaging/config.toml
 EXPOSE 9696/tcp
-ENTRYPOINT ["start-mote-server"]
-CMD ["-p 9696", "-4"]
+ENTRYPOINT ["gunicorn"]
+CMD ["--bind", "0.0.0.0:9696", "-k", "geventwebsocket.gunicorn.workers.GeventWebSocketWorker", "-w1", "mote.main:main"]

--- a/fedora-messaging.toml
+++ b/fedora-messaging.toml
@@ -1,0 +1,50 @@
+# A basic configuration for Fedora's message broker, using the example callback
+# which simply prints messages to standard output.
+#
+# This file is in the TOML format.
+amqp_url = "amqps://fedora:@rabbitmq.fedoraproject.org/%2Fpublic_pubsub"
+callback = "fedora_messaging.example:printer"
+
+[tls]
+ca_cert = "/etc/fedora-messaging/cacert.pem"
+keyfile = "/etc/fedora-messaging/fedora-key.pem"
+certfile = "/etc/fedora-messaging/fedora-cert.pem"
+
+[client_properties]
+app = "Mote"
+# Some suggested extra fields:
+# URL of the project that provides this consumer
+app_url = "https://github.com/fedora-infra/mote"
+# Contact emails for the maintainer(s) of the consumer - in case the
+# broker admin needs to contact them, for e.g.
+app_contacts_email = ["darknao@fedoraproject.org", "akashdeep.dhar@gmail.com"]
+
+[exchanges."amq.topic"]
+type = "topic"
+durable = true
+auto_delete = false
+arguments = {}
+
+# Queue names *must* be in the normal UUID format: run "uuidgen" and use the
+# output as your queue name. If your queue is not exclusive, anyone can connect
+# and consume from it, causing you to miss messages, so do not share your queue
+# name. Any queues that are not auto-deleted on disconnect are garbage-collected
+# after approximately one hour.
+#
+# If you require a stronger guarantee about delivery, please talk to Fedora's
+# Infrastructure team.
+[queues.00000000-0000-0000-0000-000000000000]
+durable = false
+auto_delete = true
+exclusive = true
+arguments = {}
+
+[[bindings]]
+queue = "00000000-0000-0000-0000-000000000000"
+exchange = "amq.topic"
+routing_keys = [ "org.fedoraproject.prod.meetbot.meeting.complete" ]  # Set this to the specific topics you are interested in.
+
+[qos]
+prefetch_size = 0
+prefetch_count = 25
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 beautifulsoup4>=4.0.0
 Flask>=2.0.0
 Flask-SocketIO>=5.1.1
+fedora-messaging>=2.1.0
+gunicorn>=20.1.0
+gevent>=21.8.0
+gevent-websocket>=0.10

--- a/src/mote/templates/mainpage.html
+++ b/src/mote/templates/mainpage.html
@@ -394,43 +394,31 @@
                 </div>
             </div>
         </div>
-        <div class="toast-container">
-            <div id="parent" class="position-fixed bottom-0 end-0 p-3" style="z-index: 11">
-            </div>
+        <div class="toast-container position-fixed bottom-0 end-0 p-3"> 
         </div>
     </body>
     <script>
         var socket = io.connect();
-        function showToast(meeting_json) {
-            meeting_count = meeting_json.length;
-            const timer = ms => new Promise(res => setTimeout(res, ms));
-            async function load() {
-                for (var i = 0; i < meeting_count; i++) {
-                    var toastDiv = $(`
-                        <div class="toast-body">
-                            <h6 id="meeting-name">`+ meeting_json[i]["msg"]["meeting_topic"] +`</h6>
-                            <div class="mt-2 pt-2 border-top">
-                                <a id="toast-btn" type="button" class="btn btn-primary btn-sm" href="`+ meeting_json[i]["msg"]["url"] +`" target="_blank">Open meeting</a>
-                                <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="toast">Close</button>
-                            </div>
-                        </div>
-                    `);
-                    var parentDiv=document.getElementById('parent');
-                    var div = document.createElement('div');
-                    div.setAttribute('class','toast');
-                    div.setAttribute('role','alert');
-                    div.setAttribute('aria-live','assertive');
-                    div.setAttribute('aria-atomic','true');
-                    $(div).append(toastDiv);
-                    $(parentDiv).append(div);
-                    var toast = new bootstrap.Toast(div, {delay: 10000});
-                    toast.show();
-                }
-            }
-            load();
+        function meetingEnded(msg){
+            var meet_dt = new Date(msg['details']['time_'] * 1000);
+            var toastDiv = $(`
+                <div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+                    <div class="toast-header">
+                        <strong class="me-auto">
+                            Meeting <a href="`+ msg['url'] +`.html" style="font-style: italic;" target="_blank">`+ msg['meeting_topic'] +`</a> has ended
+                        </strong>
+                        <small>`+ meet_dt.toLocaleTimeString() +`</small>
+                        <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+                    </div>
+                </div>
+                `);
+            var parentDiv = $('.toast-container');
+            $(parentDiv).append(toastDiv);
+            var toast = new bootstrap.Toast(toastDiv, {autohide: false});
+            toast.show();
         }
-        socket.on("show_toast", function(meeting_json) {
-            showToast(meeting_json);
+        socket.on("show_toast", function (msg) {
+            meetingEnded(msg);
         });
     </script>
 </html>


### PR DESCRIPTION
I've took the work from @subhangi2731 and adapt it a little to work with fedora-messaging.
I've switched the docker image from alpine to fedora-minimal as it is way faster to build and don't need to compile most of the python packages.

Notifications have been tweaked a bit to keep them minimal and less intrusive. They stay on screen until dismissed, as it's very unlikely the user happen to be actively monitoring the page in the 5 seconds time frame a meeting just ended.
![image](https://user-images.githubusercontent.com/693402/143308143-80e82c06-34ad-4355-b3e1-bc9150e09a20.png)
For now, the meeting link is the one provided in the fedora-messaging bus, and redirect to meetbot.fp-o.

