### PR TITLE
Detect cache corruption and work around them

### DIFF
--- a/mote/util.py
+++ b/mote/util.py
@@ -58,7 +58,11 @@ def get_meeting_type(extension):
 def get_json_cache(meeting_type):
     try:
         with open(config().json_cache_location, mode='r') as json_store:
-            cache = json.load(json_store)
+            try:
+                cache = json.load(json_store)
+            except ValueError:
+                raise RuntimeError("Cache corrupted.")
+
 
             unix_time_expiration = cache["expiry"]
             if time.time() > unix_time_expiration:


### PR DESCRIPTION
From time to time, the cache file get truncated. While I do not know
why, I see that it result in error 500 with the following traceback:

	2022-02-24 11:19:28,488 Exception on / [GET]
	Traceback (most recent call last):
	  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1817, in wsgi_app
	    response = self.full_dispatch_request()
	  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
	    rv = self.handle_user_exception(e)
	  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
	    reraise(exc_type, exc_value, tb)
	  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
	    rv = self.dispatch_request()
	  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
	    return self.view_functions[rule.endpoint](**req.view_args)
	  File "/usr/lib/python2.7/site-packages/mote/__init__.py", line 147, in index
	    latest_meetings = get_cache_data('mote:latest_meetings')
	  File "/usr/lib/python2.7/site-packages/mote/__init__.py", line 109, in get_cache_data
	    res = util.get_json_cache(meeting_type)
	  File "/usr/lib/python2.7/site-packages/mote/util.py", line 45, in get_json_cache
	    cache = json.load(json_store)
	  File "/usr/lib64/python2.7/json/__init__.py", line 290, in load
	    **kw)
	  File "/usr/lib64/python2.7/json/__init__.py", line 338, in loads
	    return _default_decoder.decode(s)
	  File "/usr/lib64/python2.7/json/decoder.py", line 366, in decode
	    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
	  File "/usr/lib64/python2.7/json/decoder.py", line 382, in raw_decode
	    obj, end = self.scan_once(s, idx)
	ValueError: Expecting object: line 1 column 3959982 (char 3959981)

By raising the right exception, it should redowload the file and fix
itself without having a admin to do a manual rm.