### PR TITLE
A couple of fixes

### DIFF
--- a/mote/main.py
+++ b/mote/main.py
@@ -24,7 +24,7 @@ import re
 from datetime import datetime
 
 import click
-from flask import abort, jsonify, render_template, request, url_for
+from flask import abort, jsonify, redirect, render_template, request, url_for
 
 from mote import app as main
 from mote import logging, socketio
@@ -124,6 +124,10 @@ def statfile(channame, cldrdate, meetname):
     cldrdate = "{:%B %d, %Y}".format(formatted_timestamp)
     if meetpath[-1] == "/":
         meetpath = meetpath[0:-1]
+    # if txt log, redirect to meetbot-raw
+    if meetname.endswith(".txt"):
+        return redirect(f"{main.config['MEETBOT_RAW_URL']}/{request.path}", code=302)
+
     meetcont = fetch_meeting_content(meetpath)
     if meetcont[0]:
         if ".log.html" in request.path:

--- a/mote/tasks.py
+++ b/mote/tasks.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import urllib.request
 
 from flask_socketio import SocketIO
 
@@ -22,16 +21,8 @@ def process_new_meet(meet):
     # reformat meetboot-raw url
     # https://meetbot.fedoraproject.org/fedora-blocker-review/2022-03-21/f36-blocker-review.2022-03-21-16.01
     basepath = meet["url"].replace(app.config["MEETBOT_URL"], "")
-    log_url = app.config["MEETBOT_RAW_URL"] + basepath + ".log.html"
-    log_path = app.config["MEETING_DIR"] + basepath + ".log.html"
-    smry_url = app.config["MEETBOT_RAW_URL"] + basepath + ".html"
+
     smry_path = app.config["MEETING_DIR"] + basepath + ".html"
-    logging.info(f"Creating dir {os.path.dirname(smry_path)}")
-    os.makedirs(os.path.dirname(smry_path), exist_ok=True)
-    logging.info(f"downloading {smry_url}...")
-    urllib.request.urlretrieve(smry_url, smry_path)
-    logging.info(f"downloading {log_url}...")
-    urllib.request.urlretrieve(log_url, log_path)
 
     # clear cache
     cache.delete_memoized(fetch_meeting_by_day, basepath.split("/")[2])


### PR DESCRIPTION
For testing purposes, we are currently downloading new meeting files from meetbot-raw when notified by fedora-messaging.
Now that we are in production, we don't need to do that anymore as we already have direct access to all meeting files locally.
Additionally, the filesystem is read-only, so the update logic is failing and prevent the calendar view from showing any new meeting.

The second commit is fixing #321 by redirecting the user to meetbot-raw when requesting meeting logs in (raw) text format.