### PR TITLE
avoid running duplicate jobs on PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,15 @@
 ---
 name: CI
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+    - main
+    - staging
+  pull_request:
+    branches:
+    - main
+    - staging
+  workflow_dispatch:
 jobs:
   ci:
     strategy:


### PR DESCRIPTION
In its current configuration, CI jobs are run twice on PRs from feature branch (or dependabot ones): 
- first one for the `push` event on said branch
- and second one for the `pull_request` event toward the `main` branch
This PR should prevent that.