### PR TITLE
add support for Redis password

### DIFF
--- a/mote/consume.py
+++ b/mote/consume.py
@@ -1,15 +1,13 @@
 import logging
-import os
 
 import rq
 from fedora_messaging.api import consume
 from fedora_messaging.config import conf
-from redis import Redis
+
+from mote import redis
 
 conf.setup_logging()
-REDIS_URL = os.environ.get("REDIS_URL") or "redis://"
-redis = Redis.from_url(REDIS_URL)
-task_queue = rq.Queue("tasks", connection=redis, default_timeout=60 * 10)
+task_queue = rq.Queue("tasks", connection=redis.conn, default_timeout=60 * 10)
 
 
 def consume_fedora_messaging_msg(message):

--- a/mote/tasks.py
+++ b/mote/tasks.py
@@ -3,12 +3,11 @@ import os
 
 from flask_socketio import SocketIO
 
-from mote import app, cache
+from mote import app, cache, redis
 from mote.modules.find import get_meetings_files
 from mote.modules.late import fetch_meeting_by_day, get_meeting_info
 
-REDIS_URL = os.environ.get("REDIS_URL") or "redis://"
-socketio = SocketIO(message_queue=REDIS_URL)
+socketio = SocketIO(message_queue=redis.url)
 
 
 def build_cache():

--- a/mote/worker.py
+++ b/mote/worker.py
@@ -1,14 +1,10 @@
 import logging
-import os
 
-import redis
 from rq import Connection, Queue, Worker
 
+from mote import redis
+
 listen = ["tasks"]
-
-REDIS_URL = os.environ.get("REDIS_URL") or "redis://"
-
-conn = redis.from_url(REDIS_URL)
 
 if __name__ == "__main__":
     handler = logging.StreamHandler()
@@ -20,6 +16,6 @@ if __name__ == "__main__":
     log.setLevel(logging.DEBUG)
     log.addHandler(handler)
 
-    with Connection(conn):
+    with Connection(redis.conn):
         worker = Worker(list(map(Queue, listen)))
         worker.work()


### PR DESCRIPTION
Allows setting a Redis password with either `REDIS_PASSWORD` env var, or `CACHE_REDIS_PASSWORD` configuration setting, that can be used by all components (cache, worker queue and socketio).