### PR TITLE
fix cache update on new meet

### DIFF
--- a/mote/tasks.py
+++ b/mote/tasks.py
@@ -22,14 +22,14 @@ def process_new_meet(meet):
     # https://meetbot.fedoraproject.org/fedora-blocker-review/2022-03-21/f36-blocker-review.2022-03-21-16.01
     basepath = meet["url"].replace(app.config["MEETBOT_URL"], "")
 
-    smry_path = app.config["MEETING_DIR"] + basepath + ".html"
+    meetlog_path = app.config["MEETING_DIR"] + basepath + ".log.html"
 
     # clear cache
     cache.delete_memoized(fetch_meeting_by_day, basepath.split("/")[2])
 
     # add files to file_cache (root, file)
     file_cache = cache.get("meetings_files")
-    file_cache.append((os.path.dirname(smry_path), os.path.basename(smry_path)))
+    file_cache.append((os.path.dirname(meetlog_path), os.path.basename(meetlog_path)))
     cache.set("meetings_files", file_cache)
 
     # send new event to clients


### PR DESCRIPTION
The `process_new_meet` function which is responsible to update the cache, is not injecting the correct filename.
This make new meetings not available through the search engine until the cache is rebuilt.