### PR TITLE
use iso8601 format for date in backend for reliability

### DIFF
--- a/mote/modules/find.py
+++ b/mote/modules/find.py
@@ -70,8 +70,6 @@ def find_meetings_by_substring(search_string: str):
                     location_list[1],
                     location_list[2],
                 )
-                formatted_timestamp = datetime.strptime(meeting_date, "%Y-%m-%d")
-                datestring = "{:%b %d, %Y}".format(formatted_timestamp)
                 if ".log.html" in meeting_filename:
                     meeting_log_filename = meeting_filename
                     meeting_summary_filename = meeting_filename.replace(".log.html", ".html")
@@ -79,11 +77,13 @@ def find_meetings_by_substring(search_string: str):
                         app.config["RECOGNIITION_PATTERN"],
                         meeting_filename.replace(".log.html", ""),
                     )
+                    meeting_datetime = datetime.strptime(
+                        f"{meeting_date}T{meeting_title.group(3)}", "%Y-%m-%dT%H.%M"
+                    )
                     meeting_object = {
                         "topic": meeting_title.group(1),
                         "channel": channel_name,
-                        "date": datestring,
-                        "time": meeting_title.group(3),
+                        "datetime": meeting_datetime.isoformat(),
                         "url": {
                             "logs": f"{app.config['MEETBOT_RAW_URL']}/{channel_name}/{meeting_date}/{meeting_log_filename}",  # noqa
                             "summary": f"{app.config['MEETBOT_RAW_URL']}/{channel_name}/{meeting_date}/{meeting_summary_filename}",  # noqa

--- a/mote/templates/base.html.j2
+++ b/mote/templates/base.html.j2
@@ -366,6 +366,7 @@
         });
         async function populate_channels(data) {
             data = JSON.parse(decodeURIComponent(data))
+            locale = Intl.NumberFormat().resolvedOptions().locale;
             initialize_search_modal();
             document.getElementsByClassName("input-group mb-3")[0].innerHTML = ""
             document.getElementById("findtext").value = "";
@@ -376,6 +377,7 @@
                 `;
             document.getElementById("find-init").innerHTML = "";
             for (let indx in data) {
+                date = new Date(data[indx].datetime);
                 $("#listfind-uols").append(`
                         <a class="list-group-item list-group-item-action" 
                         type="button" 
@@ -385,8 +387,8 @@
                                 <span>${data[indx]["topic"]}</span>
                             </div>
                             <div class="fst-italic small text-muted mt-1">
-                                <i class="fas fa-clock"></i>&nbsp;${data[indx]["time"]}&nbsp;
-                                <i class="fas fa-calendar"></i>&nbsp;${data[indx]["date"]}&nbsp;
+                                <i class="fas fa-clock"></i>&nbsp;${date.toLocaleTimeString(locale, {timeStyle: "short"})}&nbsp;
+                                <i class="fas fa-calendar"></i>&nbsp;${date.toLocaleDateString(locale, {dateStyle: "medium"})}&nbsp;
                                 <i class="fas fa-layer-group"></i>&nbsp;${data[indx]["channel"]}&nbsp;
                             </div>
                         </a>
@@ -421,12 +423,8 @@
                         "srchtext": value
                     }, function (data) {
                         results = data
-                        results.sort((a, b) => (new Date(a.date).toLocaleDateString().split("/").reverse().join(
-                                "") < new Date(b.date).toLocaleDateString().split("/").reverse().join(
-                                "")) ? 1 :
-                            ((new Date(a.date).toLocaleDateString().split("/").reverse().join("") >
-                                new Date(b
-                                    .date).toLocaleDateString().split("/").reverse().join("")) ? -1 : 0))
+                        results.sort((a, b) => (new Date(a.datetime) < new Date(b.datetime)) ? 1 :
+                            ((new Date(a.datetime) > new Date(b.datetime)) ? -1 : 0))
                     })
                     var dropdownDiv = document.getElementById('dropdown');
                     var htmlData = ""
@@ -434,8 +432,10 @@
                         htmlData += `<li><a class="dropdown-item" type="button">No meetings found</a></li>`
                     } else if (results.length !== undefined) {
 
+                        locale = Intl.NumberFormat().resolvedOptions().locale;
                         for (var i = 0; i < 5; i++) {
                             if (results[i] !== undefined) {
+			        date = new Date(results[i].datetime);
                                 htmlData +=
                                     `<li><a class="dropdown-item" type="button"
                                 target="_blank"
@@ -444,8 +444,8 @@
                                     <span style="font-size: 16px;">${results[i].topic}</span>
                                 </div>
                                 <div class="fst-italic small text-muted mt-1">
-                                    <i class="fas fa-clock"></i>&nbsp;${results[i].time}&nbsp;
-                                    <i class="fas fa-calendar"></i>&nbsp;${results[i].date}&nbsp;
+                                    <i class="fas fa-clock"></i>&nbsp;${date.toLocaleTimeString(locale, {timeStyle: "short"})}&nbsp;
+                                    <i class="fas fa-calendar"></i>&nbsp;${date.toLocaleDateString(locale, {dateStyle: "medium"})}&nbsp;
                                     <i class="fas fa-layer-group"></i>&nbsp;${results[i].channel}&nbsp;
                                 </div>
                                 </a></li>`

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -10,7 +10,7 @@ def test_find_meetings_by_substring_1(client):
     assert r is True
     assert len(d) == 1
     assert d[0]["channel"] == "fedora-meeting"
-    assert d[0]["date"] == "Jun 10, 2020"
+    assert d[0]["datetime"].startswith("2020-06-10T")
     assert d[0]["topic"] == "fedora_iot_working_group_meeting"
 
 

--- a/tests/test_fragedpt.py
+++ b/tests/test_fragedpt.py
@@ -80,7 +80,7 @@ def test_search_meeting(client):
     j = rv.get_json()
     assert len(j) > 0
     assert j[0]["channel"] == "fedora-meeting"
-    assert j[0]["date"] == "Jun 10, 2020"
+    assert j[0]["datetime"].startswith("2020-06-10T")
     assert j[0]["topic"] == "fedora_iot_working_group_meeting"
 
 


### PR DESCRIPTION
Uses ISO8601 date format when needed to make date conversion reliable and locale independent.
Also uses timestamp to sort meetings in search results.
Should fix #338.