### PR TITLE
Add type check for all urls patterns

### DIFF
--- a/mote/templates/event_summary.html.j2
+++ b/mote/templates/event_summary.html.j2
@@ -2,7 +2,7 @@
   <div class="evt-smry-title d-grid d-md-block gap-2">
      <span class="head me-4">{{ meet['title'] }}</span>
      <span class="evt-smry-length text-nowrap me-4"><i class="fas fa-clock fa-lg me-2" aria-hidden="true"></i>{{ meet['duration'] }} min</span>
-     <span class="evt-smry-length text-nowrap"><i class="far fa-calendar-alt fa-lg me-2" aria-hidden="true"></i>{{ startdate }}</span>
+     <span class="evt-smry-length text-nowrap"><i class="far fa-calendar-alt fa-lg me-2" aria-hidden="true"></i>{{ startdate.strftime("%B %d, %Y") }}</span>
   </div>
   <div class="d-grid gap-2 d-md-block">
     <div class="btn-group">

--- a/mote/templates/statfile.html.j2
+++ b/mote/templates/statfile.html.j2
@@ -14,7 +14,7 @@
                 </li>
                 <li class="list-group-item">
                     <span class="float-left"><i class="far fa-calendar-alt"></i></span>&nbsp;
-                    <span class="float-right">{{ cldrdate }}</span>
+                    <span class="float-right">{{ cldrdate.strftime("%B %d, %Y") }}</span>
                 </li>
                 <li class="list-group-item">
                     <span class="float-left"><i class="fas fa-users"></i></span>&nbsp;

--- a/tests/test_meeting_logs.py
+++ b/tests/test_meeting_logs.py
@@ -1,7 +1,4 @@
-def test_non_existing_meeting(client):
-    rv = client.get("/fedora-meeting/2020-06-10/bleh")
-    assert b'<p class="h4 body">404 Not Found</p>' in rv.data
-    assert rv.status_code == 404
+import pytest
 
 
 def test_meeting_summary(client):
@@ -39,11 +36,17 @@ def test_meeting_log_txt(client):
     assert rv.status_code == 302
 
 
-def test_invalid_path_teams(client):
-    rv = client.get("/teams/fesco/fesco.2014-02-19-18.00.log.html")
-    assert rv.status_code == 404
-
-
-def test_invalid_path_meetbot(client):
-    rv = client.get("/meetbot/fedora-meeting/2011-10-06/infrastructure.2011-10-06-19.00.html")
+@pytest.mark.parametrize(
+    "uri",
+    (
+        "/teams/fedora-qa/fedora-qa.2015-10-19-15.00.html",
+        "/teams/fesco/fesco.2014-02-19-18.00.log.html",
+        "/meetbot/fedora-meeting/2011-10-06/infrastructure.2011-10-06-19.00.html",
+        "/fedora-meeting/2020-06-10/bleh",
+        "/fedora-meeting/2013-12-21/",
+    ),
+)
+def test_invalid_uri(client, uri):
+    rv = client.get(uri)
+    assert b'<p class="h4 body">404 Not Found</p>' in rv.data
     assert rv.status_code == 404


### PR DESCRIPTION
Introduce `DateConverter` that takes (and validates) date in `YYYY-mm-dd` format and return a `datetime` object.
This makes sure routes can no longer accept unexpected URI such as `/aaa/bbb/ccc` or any other three-part URIs that we might use in the future.