### PR TITLE
encode uri where needed

### DIFF
--- a/mote/main.py
+++ b/mote/main.py
@@ -21,6 +21,7 @@
 """
 
 import re
+import urllib.parse
 
 import click
 from flask import abort, jsonify, redirect, render_template, request, url_for
@@ -100,7 +101,8 @@ def statfile(channame, cldrdate, meetname, ext):
         typecont = "Minutes"
     elif ext == "txt":
         # if txt log, redirect to meetbot-raw
-        return redirect(f"{main.config['MEETBOT_RAW_URL']}/{request.path}", code=302)
+        encoded_uri = urllib.parse.quote(request.path)
+        return redirect(f"{main.config['MEETBOT_RAW_URL']}/{encoded_uri}", code=302)
     else:
         abort(404)
 

--- a/mote/modules/late.py
+++ b/mote/modules/late.py
@@ -25,6 +25,7 @@ import json
 import os
 import os.path
 import re
+import urllib.parse
 import urllib.request as ulrq
 from datetime import datetime, timedelta
 
@@ -79,7 +80,7 @@ def get_meeting_info(meetpath):
         "attendees": len(meet[1]["peoples"]),
         "topics": len(meet[1]["topics"]),
         "length": meet[1]["duration"],
-        "url": meetpath.replace(app.config["MEETING_DIR"], "") + ".html",
+        "url": urllib.parse.quote(meetpath.replace(app.config["MEETING_DIR"], "") + ".html"),
     }
 
 


### PR DESCRIPTION
So we can handle meeting with # sign in their name.
https://meetbot.fedoraproject.org/fedora-meeting/2022-08-17/fedora_iot_working_group_meeting_#chair_pwhalen_pbrobinson_bcotton_tdawson_puiterwijk_coremodule_#topic_roll_call.2022-08-17-15.01.html
(that doesn't work)
to 
https://meetbot.fedoraproject.org/fedora-meeting/2022-08-17/fedora_iot_working_group_meeting_%23chair_pwhalen_pbrobinson_bcotton_tdawson_puiterwijk_coremodule_%23topic_roll_call.2022-08-17-15.01.html