### PR TITLE
navigation link between logs and minutes

### DIFF
--- a/mote/main.py
+++ b/mote/main.py
@@ -97,12 +97,14 @@ def getevents():
 
 @main.get("/<string:channame>/<date:cldrdate>/<string:meetname>.log.html")
 def getlogs(channame, cldrdate, meetname):
-    return statfile(channame, cldrdate, meetname, typecont="Logs")
+    url_type = url_for("getminutes", channame=channame, cldrdate=cldrdate, meetname=meetname)
+    return statfile(channame, cldrdate, meetname, typecont="Logs", url_type=url_type)
 
 
 @main.get("/<string:channame>/<date:cldrdate>/<string:meetname>.html")
 def getminutes(channame, cldrdate, meetname):
-    return statfile(channame, cldrdate, meetname, typecont="Minutes")
+    url_type = url_for("getlogs", channame=channame, cldrdate=cldrdate, meetname=meetname)
+    return statfile(channame, cldrdate, meetname, typecont="Minutes", url_type=url_type)
 
 
 @main.get("/<string:channame>/<date:cldrdate>/<string:meetname>.txt")
@@ -110,7 +112,7 @@ def getraw(channame, cldrdate, meetname):
     return statfile(channame, cldrdate, meetname, typecont="Raw")
 
 
-def statfile(channame, cldrdate, meetname, typecont):
+def statfile(channame, cldrdate, meetname, typecont, url_type):
     if typecont == "Raw":
         # if txt log, redirect to meetbot-raw
         encoded_uri = urllib.parse.quote(request.path)
@@ -133,6 +135,7 @@ def statfile(channame, cldrdate, meetname, typecont):
             timetext=meeting_title.group(3),
             typecont=typecont,
             meetcont=meetcont[1],
+            url_type=url_type
         )
 
 

--- a/mote/templates/statfile.html.j2
+++ b/mote/templates/statfile.html.j2
@@ -25,6 +25,17 @@
                     <span class="float-left"><i class="fas fa-users"></i></span>&nbsp;
                     <span class="float-right">{{ channame }}</span>
                 </li>
+                {% if typecont == "Minutes" %}
+                    <li class="list-group-item">
+                        <span class="float-left"><i class="fas fa-link"></i></span>&nbsp;
+                        <span class="float-right"><a href="{{ url_type }}">Logs</a></span>
+                    </li>
+                {% elif typecont == "Logs"%}
+                    <li class="list-group-item">
+                        <span class="float-left"><i class="fas fa-link"></i></span>&nbsp;
+                        <span class="float-right"><a href="{{ url_type }}">Minutes</a></span>
+                    </li>
+                {% endif %}
             </ul>
             <div class="card mt-2 mb-2">
                 <div class="card-header text-center head fw-bold">


### PR DESCRIPTION
# Description:

This pull request fix issue #684 
This PR addresses a request of a more seamless navigation experience between the minutes summary and the full meeting logs of a particular meeting. 

PS: the meetbot logs archive is not working [link](https://mega.nz/file/cJYykbKA#jJozcnIG-WzwlYVQUXF25lqM5A8PNl2knQObQrSpOSk), I couldn't access to the page to make a demo.